### PR TITLE
Fixed broken link on tags with spaces

### DIFF
--- a/layouts/partials/articleInfoFull.html
+++ b/layouts/partials/articleInfoFull.html
@@ -13,7 +13,7 @@
             {{ if .Params.tags }}
                 <ul class="article-tags">
                     {{ range .Params.tags }}
-                        <li><a href="{{ "tags/" | absURL }}{{ . }}">#{{ . }}</a></li>
+                        <li><a href="{{ "tags/" | absURL }}{{ . | urlize}}">#{{ . }}</a></li>
                     {{ end }}
                 </ul>
         {{ end }}


### PR DESCRIPTION
Clicking the link to tag with a space would 404, this adds a hyphen which links to the correct page.