### PR TITLE
Add support for custom CSS files

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,6 +14,10 @@
 
 <link rel="stylesheet" href="{{ "css/style.css" | absURL }}?rnd={{ now.Unix }}" />
 
+{{ range .Site.Params.customCSS -}}
+<link rel="stylesheet" href="{{ . | absURL }}?rnd={{ now.Unix }}">
+{{- end }}
+
 {{ template "_internal/opengraph.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
 


### PR DESCRIPTION
This allows end users to add additional CSS files for use in their site.
They would do this by adding
```
[params]
  customCSS = [
    "mycss.css"
  ]
```
into their config file.

This should assist with #12 