### PR TITLE
add rel attribute to address lighthouse audit issue

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,3 @@
 <p>© {{ if isset .Site.Params "author"}}{{ .Site.Params.author }}, {{end}}{{ now.Year }}<br>
-{{ i18n "powered" | humanize }} <a target="_blank" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.
+{{ i18n "powered" | humanize }} <a target="_blank" rel="noopener noreferrer" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.
 </p>


### PR DESCRIPTION
This link was getting flagged in lighthouse audits, so adding the `rel` attribute
to address it.

![unsafe links](https://user-images.githubusercontent.com/5070516/85709040-bdb46d00-b6dc-11ea-9ec3-6bc5d73e2d15.png)

Used both `noopener` and `noreferrer`, since some older browsers don't support
`noopener`.