### PR TITLE
Add margin-bottom to theme-switcher.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -442,6 +442,7 @@ ul.language-select > li {
     font-size: 16px;
     border: none;
     margin-right: 1em;
+    margin-bottom: 1em;
 }
 
 /* Media Queries */


### PR DESCRIPTION
I think this minor change improves the theme when viewed on narrow screens. See linked issue for visual example. Resolves #61.