### PR TITLE
Replace css rules for nav links to assist flow

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -503,12 +503,9 @@ ul.language-select > li, ul.footer-menu > li {
         padding: 0.5em 0;
     }
 
-    header nav a:first-of-type {
-        margin-left: 0;
-    }
-
     header nav a {
-        margin-left: 5%;
+        display: inline-block;
+        margin: 0 2.5%;
     }
 
     .post-navigation {


### PR DESCRIPTION
Currently, there are two rules which control the margin of the links in the navigation bar:

https://github.com/Mitrichius/hugo-theme-anubis/blob/460a61701f5edb8e8dfef63dcd25992ccd4d2e1f/assets/css/main.css#L506-L512

They treat the first link separately from the rest and then give the rest of the links asymmetric margins. This results in the links touching the edge of the grey background box for some choices of text on small screens:

![image](https://user-images.githubusercontent.com/9048525/97267890-2ecd7380-17e8-11eb-9873-4f2355234ecb.png)

You can also see that some longer links are split over two lines where it would instead make sense for them to be grouped together. This pull request symmetrizes the margins of the links and also changes their display mode to prefer grouping link text together when inserting line breaks:

![image](https://user-images.githubusercontent.com/9048525/97268411-19a51480-17e9-11eb-85be-604f35af167f.png)

However, the lack of margins on the edges of the links may have been intentional. See the 0 left/right padding here:

https://github.com/Mitrichius/hugo-theme-anubis/blob/460a61701f5edb8e8dfef63dcd25992ccd4d2e1f/assets/css/main.css#L498-L504

Please let me know if the lack of spacing was intended.