### PR TITLE
french corrections

### DIFF
--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -35,10 +35,10 @@ toAllCategories:
   other: "vers toutes les catégories"
 
 skipToContent:
-  other: "passer au contenu principal"
+  other: "aller au contenu"
 
 darkTheme:
   other: "thème sombre"
 
 lightTheme:
-  other: "thème léger"
+  other: "thème clair"


### PR DESCRIPTION
Suggestion for the french translation :

thème léger -> **thème clair**
light in english can be translated to both _léger_ (= not heavy) and _clair_ (= not dark) so it's a funny translation

passer au contenu principal -> **aller au contenu**
I think _aller au contenu_ is shorter and more used in french blogs
cf. https://www.accede-web.com/notices/fonctionnelle-graphique/recommandations-complementaires/prevoir-lapparence-des-liens-devitement/

