### PR TITLE
uteranc.es support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Anubis is a simple minimalist theme for [Hugo blog engine](https://gohugo.io/).
 - Mobile support
 - Google Analytics
 - Disqus
+- Utteranc.es
 - RSS feeds
 - Translations (en, ru, fr, pl)
 - Custom CSS/JS
@@ -70,6 +71,11 @@ params:
   paginationSinglePost: true
   style: light-without-switcher
   readMore: false
+  # utteranc.es support
+  utterancesRepo: ""  # mandatory
+  utterancesTheme: "" # optional
+  utterancesIssue: "" # optional
+  utterancesLabel: "" # optional
   webmentions:
     login: hugo-theme-anubis
     pingback: true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,12 @@ googleAnalytics = ""
    style = "light-without-switcher"
    readMore = false
 
+   # utteranc.es support
+   utterancesRepo = ""  # mandatory
+   utterancesTheme = "" # optional
+   utterancesIssue = "" # optional
+   utterancesLabel = "" # optional
+
 [menu]
 
   [[menu.main]]

--- a/exampleSiteMultilingual/config.toml
+++ b/exampleSiteMultilingual/config.toml
@@ -19,6 +19,12 @@ googleAnalytics = ""
    style = "light-without-switcher"
    readMore = false
 
+   # utteranc.es support
+   utterancesRepo = ""  # mandatory
+   utterancesTheme = "" # optional
+   utterancesIssue = "" # optional
+   utterancesLabel = "" # optional
+
 [languages.en]
   languageName = "English"
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,4 +25,8 @@
         {{ template "_internal/disqus.html" . }}
     {{ end }}
 
+    {{ if .Site.Params.UtterancesRepo }}
+        {{ partial "utterances.html" . }}
+    {{ end }}
+
 {{ end }}

--- a/layouts/partials/utterances.html
+++ b/layouts/partials/utterances.html
@@ -1,0 +1,11 @@
+{{ $theme := .Site.Params.UtterancesTheme | default "github-light" }}
+{{ $label := .Site.Params.UtterancesLabel | default "" }}
+{{ $issue := .Site.Params.UtterancesIssue | default "url" }}
+<script src="https://utteranc.es/client.js"
+        repo="{{- .Site.Params.UtterancesRepo -}}"
+        theme="{{ $theme }}"
+        label="{{ $label }}"
+        issue-term="{{ $issue }}"
+        crossorigin="anonymous"
+        async>
+</script>


### PR DESCRIPTION
## Summary

This PR adds support for the [utteran.es](https://utteranc.es/), a free and open source alternative to Disqus that stores all data in Github issues.