### PR TITLE
Footer-extra, pagination-extra, post-info, webmention-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ params:
   utterancesIssue: "" # optional
   utterancesLabel: "" # optional
   webmentions:
+    url: https://yourdomain.com/webemntions/receive
     login: hugo-theme-anubis
     pingback: true
 
@@ -129,6 +130,10 @@ To hide a post from the RSS feed, just add `disable_feed: true` to its front mat
 
 ### Pagination on post single page
 Enabled by `paginationSinglePost` param in `params` section of config.
+
+### Webmentions
+To provide webmention support you can **either** specify your webmention.io username with `login: webmentionusername` **or** specify a link to your custom webmention endpoint with `url: https://yourdomain.com/webemntions/receive`.
+If you use webmention.io you can also enable pingback with `pingback: true` 
 
 ## Contributing
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,8 @@
         {{ end }}
         <div class="copyright">
             <p>© {{ if isset .Site.Params "author"}}{{ .Site.Params.author }}, {{end}}{{ now.Year }}<br>
-            {{ i18n "powered" | humanize }} <a target="_blank" rel="noopener noreferrer" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.
+            {{ i18n "powered" | humanize }} <a target="_blank" rel="noopener noreferrer" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.<br>
+            {{ partial "footer-extra.html" . }}
             </p>  
         </div> 
 
@@ -23,5 +24,4 @@
     </div>
 
     {{ partial "h-card.html" . }}
-    {{ partial "footer-extra.html" . }}
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,9 @@
         <link rel="pingback" href="https://webmention.io/{{.Site.Params.webmentions.login}}/xmlrpc" />
     {{ end }}
 {{ end }}
+{{ if isset .Site.Params.webmentions "url"  }}
+    <link rel="webmention" href="{{.Site.Params.webmentions.url}}" />
+{{ end }}
 
 <!-- Article tags -->
 <!-- <meta property="article:published_time" content="">

--- a/layouts/partials/pagination-extra.html
+++ b/layouts/partials/pagination-extra.html
@@ -1,0 +1,1 @@
+<!--for overriding-->

--- a/layouts/partials/paginationPost.html
+++ b/layouts/partials/paginationPost.html
@@ -12,3 +12,5 @@
         </div>
     </div>
 {{ end }}
+
+{{ partial "pagination-extra.html" . }}

--- a/layouts/partials/postInfo.html
+++ b/layouts/partials/postInfo.html
@@ -9,7 +9,7 @@
     {{ end }}
     
     <a class="post-hidden-url u-url" href="{{ .Permalink }}">{{ .Permalink }}</a>
-    <a href={{ .Site.BaseURL }} class="p-name p-author post-hidden-author" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
+    <a href={{ .Site.BaseURL }} class="p-name p-author post-hidden-author h-card" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
 
 
     <div class="post-taxonomies">

--- a/layouts/partials/postInfo.html
+++ b/layouts/partials/postInfo.html
@@ -9,7 +9,8 @@
     {{ end }}
     
     <a class="post-hidden-url u-url" href="{{ .Permalink }}">{{ .Permalink }}</a>
-    <div class="post-hidden-author p-author">{{ .Params.author | default .Site.Params.author }}</div>
+    <a href={{ .Site.BaseURL }} class="p-name p-author post-hidden-author" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
+
 
     <div class="post-taxonomies">
         {{ if .Params.categories }}


### PR DESCRIPTION
## This PR includes more then one change and you are welcome to cherry-pick

1. Move the footer-extra inside the copyright diff so that there is no weird gap between the lines.
2. Add an extra to the pagination.html. This is kinda specific but allows me to include a webmention widget right before the footer.
3. Changed the post-info to include the author name and the base url for better webmention support.
4. Add the ability to set a webmention URL in the config without disrupting current config settings. See my comment [here](https://github.com/Mitrichius/hugo-theme-anubis/issues/75#issuecomment-784136709)