### PR TITLE
Stop changing display style of summary to block

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -49,8 +49,7 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
     display: block;
 }	
 


### PR DESCRIPTION
Changing the display style to `block` removes the disclosure triangle which can make it difficult to understand that an element is a `details`. If this is an intended part of the design, feel free to reject this pull request.