### PR TITLE
fix: put quotes around BaseUrl for author

### DIFF
--- a/layouts/partials/post-info.html
+++ b/layouts/partials/post-info.html
@@ -9,7 +9,7 @@
     {{ end }}
     
     <a class="post-hidden-url u-url" href="{{ .Permalink }}">{{ .Permalink }}</a>
-    <a href={{ .Site.BaseURL }} class="p-name p-author post-hidden-author h-card" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
+    <a href="{{ .Site.BaseURL }}" class="p-name p-author post-hidden-author h-card" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
 
 
     <div class="post-taxonomies">


### PR DESCRIPTION
This makes sure not destroying the template without setting the BaseURL