### PR TITLE
Fixing broken pagination links on the post page

### DIFF
--- a/layouts/partials/post-pagination.html
+++ b/layouts/partials/post-pagination.html
@@ -2,12 +2,12 @@
     <div class="pagination post-pagination">
         <div class="left pagination-item {{ if not .NextInSection }}disabled{{ end }}">
             {{ if .NextInSection }}
-                <a href="{{ .NextInSection.Permalink | relLangURL }}">{{ .NextInSection.Title }}</a>
+                <a href="{{ .NextInSection.RelPermalink }}">{{ .NextInSection.Title }}</a>
             {{ end }}
         </div>
         <div class="right pagination-item {{ if not .PrevInSection }}disabled{{ end }}">
             {{ if .PrevInSection }}
-                <a href="{{ .PrevInSection.Permalink | relLangURL }}">{{ .PrevInSection.Title }}</a>
+                <a href="{{ .PrevInSection.RelPermalink }}">{{ .PrevInSection.Title }}</a>
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
This PS is for the issue https://github.com/Mitrichius/hugo-theme-anubis/issues/95.

Fixing link to next/prev post in the post page by analogy with post summary ([layouts/partials/post-summary.html](https://github.com/Mitrichius/hugo-theme-anubis/blob/5dab60e04a37896c09a32137aefe821c63b3af04/layouts/partials/post-summary.html)).

This PR has been tested manually on my local development environment with the following test-cases:
* Pagination for all english posts   :heavy_check_mark:
* Pagination for all russian posts   :heavy_check_mark: