### PR TITLE
Updating link format for Telegram

### DIFF
--- a/data/social.yaml
+++ b/data/social.yaml
@@ -9,7 +9,7 @@ social_icons:
   snapchat: https://www.snapchat.com/s/%s
   soundcloud: https://soundcloud.com/%s
   spotify: https://open.spotify.com/user/%s
-  telegram: tg://resolve?domain=%s
+  telegram: https://t.me/%s
   twitch: https://www.twitch.tv/%s
   twitter: https://twitter.com/%s
   vk: https://vk.com/%s


### PR DESCRIPTION
That's a screenshot from an official Telegram client for Ubuntu, showing the example of Telegram-link (mine in this case =) ):

![image](https://user-images.githubusercontent.com/10430347/135489158-407747be-9d9d-4973-a32f-8f9d4c5383cb.png)
