### PR TITLE
Tweak theme to detect and use front matter "description" field

### DIFF
--- a/layouts/partials/post-summary.html
+++ b/layouts/partials/post-summary.html
@@ -7,9 +7,9 @@
     {{ if not .Site.Params.disableSummary }}
         <div class="content post-summary p-summary">
             {{ if isset .Params "description" }}
-            {{ .Description }}
+            {{ .Description | safeHTML }}
             {{ else }}
-            {{ .Summary }}&hellip;
+            {{ .Summary | safeHTML }}&hellip;
             {{ end }}
         </div>
     {{ end }}


### PR DESCRIPTION
# PR Summary
This proposed change allows this theme to use a description when it is specified in the front matter, falling back to an automatically generated summary otherwise.

## Explanation
The Hugo `.Summary` var is okay, but it doesn't respect markdown well. For example, if your post is formatted like so:

```
# Title
Blog content text, blah blah
```

The summary object converts this to `Title Blog context text, blah blah`; squishing headings and body text together. A way to deal with this in many themes is to allow each post to specify a "description" in the front matter:

```
---
title: My Blog Post
description: A manual short summary of the blog content
date: 1970-01-01
draft: false
---
Blog Content...
```

This proposed change, based on a similar layout in the [archie](/hamogor/archie/blob/main/layouts/index.html) theme, does the following:
1. Check the front matter for a "description" parameter.
2. If it exists, use the `.Description` Hugo variable for the post summary
3. Otherwise, use the `.Summary` variable as normal.

The addition of `&hellip` is just escaped HTML for the **horizontal ellipsis** character (…), to show the text continues beyond the summary shown.