### PR TITLE
Fixing a bug with empty <title>

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="referrer" content="no-referrer-when-downgrade">
 
-{{ partial "title.html" }}
+{{ partial "title.html" . }}
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}">
 
 {{ with .OutputFormats.Get "rss" -}}


### PR DESCRIPTION
### Bug description

In pull-request https://github.com/Mitrichius/hugo-theme-anubis/pull/106 I missed one important symbol (the dot).
And this caused an `<title>` to be empty on each page:
```bash
curl -s 'https://iakunin.dev/about/' | grep '<title>'
<title></title>
```

Sorry about that.

### Fix description
I just added the forgotten dot and that's it!