### PR TITLE
Extracting favicons to a separate partition.

### DIFF
--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -1,0 +1,2 @@
+<link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | absURL }}">
+<link rel="apple-touch-icon-precomposed" href="{{ "favicon.png" | absURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,9 +11,7 @@
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{ end -}}
 
-<link rel="icon" type="image/x-icon" href="{{ "favicon.ico" | absURL }}">
-<link rel="apple-touch-icon-precomposed" href="{{ "favicon.png" | absURL }}">
-
+{{ partial "favicons.html" . }}
 {{ partial "resource.html" (dict "context" . "type" "css" "filename" "css/main.css") }}
 
 {{ range .Site.Params.customJS -}}


### PR DESCRIPTION
I extracted favicons to a separate partition.

Why? Because it's the only way to enable overriding in the client's code.
Just by analogy with https://github.com/Mitrichius/hugo-theme-anubis/pull/106.