### PR TITLE
Fixing pagination bug 

### DIFF
--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,15 +1,15 @@
 {{ if or ( .Paginator.HasPrev ) ( .Paginator.HasNext ) }}
     {{ $toNewPostsMessage := i18n "toNewPosts" }}
-    {{ $toOldPostsMessage := i18n "toOldPosts" }}    
+    {{ $toOldPostsMessage := i18n "toOldPosts" }}
     <div class="pagination">
         <div class="left pagination-item {{ if not .Paginator.HasPrev }}disabled{{ end }}">
             {{ if .Paginator.HasPrev }}
-                <a href="{{ .Paginator.Prev.URL | relLangURL }}">{{ $toNewPostsMessage }}</a>
+                <a href="{{ .Paginator.Prev.URL }}">{{ $toNewPostsMessage }}</a>
             {{ end }}
         </div>
         <div class="right pagination-item {{ if not .Paginator.HasNext }}disabled{{ end }}">
             {{ if .Paginator.HasNext }}
-                <a href="{{ .Paginator.Next.URL | relLangURL }}">{{ $toOldPostsMessage }}</a>
+                <a href="{{ .Paginator.Next.URL }}">{{ $toOldPostsMessage }}</a>
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
Hi, @Mitrichius! Here is a bug that I found.

### Steps to reproduce
1. Set `baseUrl` config parameter to `http://localhost/some/prefix/`
2. Decrease `paginate` config parameter to 2
3. Go to home page
4. Click "Next" pagination button

### Expected behaviour
Page successfully opened.

### Actual behaviour
"404 - Page not found" error occurred.

### Why did this bug happen? 
Because link looks like: `http://localhost/some/preffix/some/preffix/page/2/`.
As we can see, `/some/preffix/` part is duplicated here.

### How can we fix it?
We can fix this bug just by getting rid of  `relLangURL` function call.
Original `.Paginator.Next.URL` already contains all the necessary language information.

### Tested on
:heavy_check_mark: English language, baseUrl with prefix
:heavy_check_mark: Russian language, baseUrl with prefix
:heavy_check_mark: English language, baseUrl without prefix
:heavy_check_mark: Russian language, baseUrl without prefix