### PR TITLE
Fixing wrong categories links below the post 

### DIFF
--- a/layouts/partials/post-info.html
+++ b/layouts/partials/post-info.html
@@ -7,7 +7,7 @@
     {{ if .Params.date }}
         <div class="post-date dt-published">{{ .Params.date.Format $dateFormat }}</div>
     {{ end }}
-    
+
     <a class="post-hidden-url u-url" href="{{ .Permalink }}">{{ .Permalink }}</a>
     <a href="{{ .Site.BaseURL }}" class="p-name p-author post-hidden-author h-card" rel="me">{{ .Params.author | default .Site.Params.author }}</a>
 
@@ -16,7 +16,7 @@
         {{ if .Params.categories }}
             <ul class="post-categories">
                 {{ range .Params.categories }}
-                    <li><a href="{{ "categories/" | urlize | absLangURL }}">{{ . }}</a></li>
+                    <li><a href="{{ "categories/" | absLangURL }}{{ . | urlize }}">{{ . }}</a></li>
                 {{ end }}
             </ul>
             {{ end }}


### PR DESCRIPTION
Hi, @Mitrichius! Here is a bug that I found.

### Problem description
For now, all the categories links refers to `/category/` page.

You can see it here: https://deploy-preview-112--hugo-theme-anubis.netlify.app/

<img src="https://user-images.githubusercontent.com/10430347/140624221-a3fa7af8-16f5-4757-a5e1-c82f280888e3.png" width=430 height=276 /> 


### Solution
I fixed this bug using the same logic as for tag list ([see here](https://github.com/Mitrichius/hugo-theme-anubis/blob/master/layouts/partials/post-info.html#L26)).