### PR TITLE
Fixing bug with wrong "goToAll" link on taxonomy page (tags, categories)

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
     <h1>{{ i18n .Data.Singular | humanize }}: {{ .Title }}</h1>
     <div class="post-info">
-        <a href="{{ (printf "%s/%s" .Site.LanguagePrefix .Data.Plural) | absLangURL }}">{{ i18n (printf "toAll%s" (.Data.Plural | humanize )) | humanize }}</a>
+        <a href="{{ (print .Data.Plural "/") | relLangURL }}">{{ i18n (printf "toAll%s" (.Data.Plural | humanize )) | humanize }}</a>
     </div>
     {{ range .Paginator.Pages }}
         {{ partial "post-summary.html" . }}


### PR DESCRIPTION
Hi, @Mitrichius! Here is a bug that I found.

### Steps to reproduce
* Set up `baseURL` config parameter with some prefix (for example, `http://localhost/some/prefix/`)
* Go to one tag page (for example, "markdown" tag page - http://localhost:1313/some/prefix/tags/markdown/)
* Click "To all tags" button (screenshot with the placement of this button: https://s.mail.ru/fKhT/ZkCFccccm)


### Expected behaviour
* All tags page successfully opened 
* Expected page url is `http://localhost:1313/some/prefix/tags`


### Actual behaviour
* Unable to open all tags page (404 page not found)
* Actual page url is `http://localhost:1313/tags`


As you can see, there is no blog url prefix in the actual link.


### How can we fix that?
Nice and easy, as always :)

Hugo-function [`relLangURL`](https://gohugo.io/functions/rellangurl) does exactly what we want to solve our problem.
We can just take this function and apply it in `_default/taxonomy.html` layout.

And that's it!

P.S. I added a forward slash at the end of the link (`print .Data.Plural "/"`).
Why? Just an optimisation to get rid of redundant 301-redirect.
See an http-response when we trying to open a page without forward slash in the end:

```
curl -I 'https://dmitrykolosov.ru/tags'
HTTP/1.1 301 Moved Permanently
cache-control: public, max-age=0, must-revalidate
content-type: text/html; charset=UTF-8
date: Sun, 07 Nov 2021 10:35:03 GMT
etag: "3f9dc9646b7df0d87b90932a4440d2d6-ssl"
strict-transport-security: max-age=31536000
x-nf-request-id: 01FKWZFCTP1ZDJEYC5G02PMMRK
server: Netlify
location: /tags/
content-length: 6773
age: 30
```

Pay attention to `location: /tags/` response header.

The same story with any site's page without forward slash in the end. Except for the home page.




### Test-cases
:heavy_check_mark: Tag page, Russian language, baseUrl = `http://localhost/`
:heavy_check_mark:  Tag page, Russian language, baseUrl = `http://localhost/some/prefix/`
:heavy_check_mark:  Tag page, English language, baseUrl = `http://localhost/`
:heavy_check_mark:  Tag page, English language, baseUrl = `http://localhost/some/prefix/`

:heavy_check_mark:  Category page, Russian language, baseUrl = `http://localhost/`
:heavy_check_mark:  Category page, Russian language, baseUrl = `http://localhost/some/prefix/`
:heavy_check_mark:  Category page, English language, baseUrl = `http://localhost/`
:heavy_check_mark:  Category page, English language, baseUrl = `http://localhost/some/prefix/`