### PR TITLE
Fixing UX-issue with language-switcher

### DIFF
--- a/layouts/partials/language-switcher.html
+++ b/layouts/partials/language-switcher.html
@@ -1,5 +1,16 @@
-<ul class="language-select">
-{{ range $.Site.Home.AllTranslations }}
-<li><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
+{{ if .IsTranslated }}
+    {{ $pageLang := .Page.Lang}}
+    <ul class="language-select">
+        {{ range .AllTranslations }}
+            {{ if eq .Lang $pageLang }}
+                <li>
+                    {{ .Language.LanguageName }}
+                </li>
+            {{ else }}
+                <li>
+                    <a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+                </li>
+            {{ end }}
+        {{ end }}
+    </ul>
 {{ end }}
-</ul>

--- a/layouts/partials/language-switcher.html
+++ b/layouts/partials/language-switcher.html
@@ -1,16 +1,15 @@
-{{ if .IsTranslated }}
+<ul class="language-select">
     {{ $pageLang := .Page.Lang}}
-    <ul class="language-select">
-        {{ range .AllTranslations }}
-            {{ if eq .Lang $pageLang }}
-                <li>
-                    {{ .Language.LanguageName }}
-                </li>
-            {{ else }}
-                <li>
-                    <a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
-                </li>
-            {{ end }}
+    {{ $translations := .AllTranslations }}
+    {{ if not .IsTranslated }}
+        {{ $translations = $.Site.Home.AllTranslations }}
+    {{ end }}
+
+    {{ range $translations }}
+        {{ if eq .Lang $pageLang }}
+            <li>{{ .Language.LanguageName }}</li>
+        {{ else }}
+            <li><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
         {{ end }}
-    </ul>
-{{ end }}
+    {{ end }}
+</ul>


### PR DESCRIPTION
Hi, @Mitrichius! The fourth pull-request from me during this long weekend :)

I'm not sure if it's a bug. Maybe we can categorise it as a user-experience issue. 
Anyway, I think I should share it with you.


### Problem description
For now, we have a language switcher at the bottom of the page (see [screenshot](https://s.mail.ru/uerQ/oWnczq5FB)).
This language switcher works this way: it always transfers the user to the home page (for selected language).

Imagine, we're currently on https://dmitrykolosov.ru/posts/ page.
As a user, I scrolled down to the bottom of the page and see "oh, the language switcher".
And I clicked on "English" it aaaaaaand ... I've transferred to the home page.

Is this what I expected? Not exactly. 
It would be better if I've been transferred to the same "/posts" page, but its English version (https://dmitrykolosov.ru/en/posts/).

This logic should be applied to all blog pages.

And in this pull-request you can see how I achieved this desired behaviour.
Feel free to ask me any questions on implementation details.

I've already deployed this fix to [my blog](https://iakunin.dev/).
So can play with this live demo :)