### PR TITLE
Fix twitter warning

### DIFF
--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSiteMultilingual/content/post/rich-content.md
+++ b/exampleSiteMultilingual/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/exampleSiteMultilingual/content/post/rich-content.pl.md
+++ b/exampleSiteMultilingual/content/post/rich-content.pl.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 


### PR DESCRIPTION
`WARN 2021/11/07 15:28:31 The "twitter_simple" shortcode will soon require two named parameters: user and id. See "/opt/build/repo/exampleSiteMultilingual/content/post/rich-content.md:26:1"`
...