### PR TITLE
allow emoji to be used in i18n override

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,7 @@
     {{ end }}
 </head>
 <body>
-    <a class="skip-main" href="#main">{{ i18n "skipToContent" | humanize }}</a>
+    <a class="skip-main" href="#main">{{ i18n "skipToContent" }}</a>
     <div class="container">
         <header class="common-header"> 
             {{ block "header" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
         {{ end }}
         <div class="copyright">
             <p>© {{ if isset .Site.Params "author"}}{{ .Site.Params.author }}, {{end}}{{ now.Year }}<br>
-            {{ i18n "powered" | humanize }} <a target="_blank" rel="noopener noreferrer" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.<br>
+            {{ i18n "powered" }} <a target="_blank" rel="noopener noreferrer" href="https://gohugo.io/">Hugo</a>, {{ i18n "theme" }} <a target="_blank" rel="noopener noreferrer" href="https://github.com/mitrichius/hugo-theme-anubis">Anubis</a>.<br>
             {{ partial "footer-extra.html" . }}
             </p>  
         </div> 

--- a/layouts/partials/post-summary.html
+++ b/layouts/partials/post-summary.html
@@ -13,7 +13,7 @@
     {{ end }}
     {{ if and (.Truncated) (.Site.Params.readMore) }}
         <div class="read-more">
-            <a class="u-url" href="{{ .RelPermalink }}">{{ i18n "readMore" | humanize }}</a>
+            <a class="u-url" href="{{ .RelPermalink }}">{{ i18n "readMore" }}</a>
         </div>
     {{ end }}
     

--- a/layouts/partials/theme-switcher.html
+++ b/layouts/partials/theme-switcher.html
@@ -5,7 +5,7 @@
 
 {{ if not (in (slice "light-without-switcher" "dark-without-switcher" "auto-without-switcher") $style) }}
     <button class="theme-switcher">
-        {{ i18n "darkTheme" | humanize }}
+        {{ i18n "darkTheme" }}
     </button>
 
     <script>
@@ -54,7 +54,7 @@
 
     function changeButtonText()
     {   
-        switchButton.textContent = currentTheme == 'dark' ?  {{ i18n "lightTheme" | humanize }} : {{ i18n "darkTheme" | humanize }}
+        switchButton.textContent = currentTheme == 'dark' ?  {{ i18n "lightTheme" }} : {{ i18n "darkTheme" }}
     }
 
     function switchTheme(e) {


### PR DESCRIPTION
I was trying to add emoji to some of the i18n text (e.g. light/dark theme selector), and I discovered that those emoji got stripped away when rendered.

After examining the template, it seems those i18n text got piped to the [humanize](https://gohugo.io/functions/humanize/) filter which are mainly to format non-user generated content (e.g. readable name from a url slug).

This PR removes the extra `humanize` filter, so emoji can be used.

---

My i18n override:

```yml
darkTheme:
  other: "🌘"

lightTheme:
  other: "☀️"
```
