### PR TITLE
Initialise `go` module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Mitrichius/hugo-theme-anubis
+
+go 1.18


### PR DESCRIPTION
* This will enable the theme to be imported as `hugo` module with a simple `module.imports` in the `config` file
* Removes the messy git submodule