### PR TITLE
fix: theme switcher not change button text

### DIFF
--- a/layouts/partials/theme-switcher.html
+++ b/layouts/partials/theme-switcher.html
@@ -58,7 +58,7 @@ function detectCurrentScheme() {
     return 'light'
 }
 
-function changeButtonText(switchButton)
+function changeButtonText()
 {   
     if (switchButton) {
         switchButton.textContent = currentTheme == 'dark' ?  {{ i18n "lightTheme" }} : {{ i18n "darkTheme" }}


### PR DESCRIPTION
found theme switcher button text not changed after click, so I check the code,
seems changeButtonText does not need that local variable, and I made a small fix for myself.
