### PR TITLE
`lastMod` support

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -51,3 +51,6 @@ lightTheme:
 
 readNext:
   other: "Read next"
+
+lastMod:
+  other: "Last modified:"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -48,3 +48,6 @@ lightTheme:
 
 readNext:
   other: "Читать далее"
+
+lastMod:
+  other: "Отредактировано:"

--- a/layouts/partials/post-info.html
+++ b/layouts/partials/post-info.html
@@ -2,10 +2,20 @@
 {{ if .Site.Params.dateFormat }}
     {{ $dateFormat = .Site.Params.dateFormat }}
 {{ end }}
+{{ $machineDateFormat := "2006-01-02" }}
 
 <div class="post-info">
     {{ if .Params.date }}
-        <div class="post-date dt-published"><a class="u-url" href="{{ .RelPermalink }}">{{ .Params.date.Format $dateFormat }}<a/></div>
+        <div class="post-date dt-published">
+            <a class="u-url" href="{{ .RelPermalink }}"><time datetime="{{ .Params.date.Format $machineDateFormat }}">
+                {{- .Params.date.Format $dateFormat -}}
+            </time></a>
+            {{ if ne .Params.date .Params.lastMod -}}
+                [{{ i18n "lastMod" }} <time datetime="{{ .Params.lastMod.Format $machineDateFormat }}">
+                    {{- .Params.lastMod.Format $dateFormat -}}
+                </time>]
+            {{- end }}
+        </div>
     {{ end }}
 
     <a class="post-hidden-url u-url" href="{{ .Permalink }}">{{ .Permalink }}</a>


### PR DESCRIPTION
Based upon #183

Improvemtns:
- doesn't change default date format,
- doesn't ignore user's `dateFormat` preference,
- doesn't overwrite link to the post with `/arsip/`,
- has some i18n (sadly, only Russian and English),
- fixes the `<a/>` typo.

Non-improvements:
- still silently omits `lastMod` if it's not a valid date,
- still uses the cool `<time>` HTML tags.