### PR TITLE
Cull excessive JS/CSS for `{dark,light}-without-swticher` styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,22 +1,32 @@
 {{ $light := resources.Get "css/light.css" }}
 {{ $dark := resources.Get "css/dark.css" }}
 
-{{ $light.Content }}
+{{ $style := "light-without-switcher" }}
+{{ if and (isset site.Params "style") (ne site.Params.style "") }}
+    {{ $style = site.Params.style | lower }}
+{{ end }}
 
-{{ if eq site.Params.style "dark-without-switcher" }}
+{{ if eq $style "dark-without-switcher" }}
 :root {
     {{ $dark.Content }}
 }
-{{ else if eq site.Params.style "auto-without-switcher" }}
+
+{{ else }}
+
+{{ $light.Content }}
+
+{{ if eq $style "auto-without-switcher" }}
 @media (prefers-color-scheme: dark) {
     :root {
         {{ $dark.Content }}
     }
 }
-{{else }}
+{{ else if ne $style "light-without-switcher" }}
 [data-theme="dark"] {
     {{ $dark.Content }}
 }
+{{ end }}
+
 {{ end }}
 
 /* Basic */

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,6 +21,12 @@
 
 {{ partial "favicons.html" . }}
 
+{{ $style := "light-without-switcher" }}
+{{ if and (isset site.Params "style") (ne site.Params.style "") }}
+    {{ $style = site.Params.style | lower }}
+{{ end }}
+
+{{ if not (in (slice "light-without-switcher" "dark-without-switcher") $style) }}
 <style>
   body {
     visibility: hidden;
@@ -36,6 +42,7 @@
     }
   </style>
 </noscript>
+{{end}}
 
 {{ partial "resource.html" (dict "context" . "type" "css" "filename" "css/main.css") }}
 

--- a/layouts/partials/theme-switcher.html
+++ b/layouts/partials/theme-switcher.html
@@ -3,7 +3,8 @@
     {{ $style = site.Params.style | lower }}
 {{ end }}
 
-{{ if not (in (slice "light-without-switcher" "dark-without-switcher" "auto-without-switcher") $style) }}
+{{ if not (in (slice "light-without-switcher" "dark-without-switcher") $style) }}
+{{ if ne "auto-without-switcher" $style }}
     <button class="theme-switcher">
         {{ i18n "darkTheme" }}
     </button>
@@ -85,3 +86,4 @@ function showContent() {
     document.body.style.opacity = 1;
 }
 </script>
+{{ end }}


### PR DESCRIPTION
When the `dark-without-switcher` or `light-without-switcher` style is selected, we don't need any of the JS code responsible for switching themes or restoring the opacity and visibility of the body (which is initially hidden, see #139), nor the CSS that actually hides it. We also don't need to have the contents of both `dark.css` & `light.css` embedded into `main.css`.

This is what the PR focuses on.
