### PR TITLE
Add param sectionsWithFullContentOnListPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Anubis is a simple minimalist theme for [Hugo blog engine](https://gohugo.io/).
 - Dark mode (automatic / by switcher)
 - Pagination
 - Multiple taxonomies: tags, categories, authors
+- Multiple sections: posts, notes, etc with customization
 - Archive
 - Table of Contents
 - Open Graph and Twitter Cards support
@@ -97,6 +98,8 @@ params:
   dateFormat: "2006-01-02"
   paginationSinglePost: true
   style: light-without-switcher
+  mainSections: [ "posts" ] # which sections should be on index/main page
+  sectionsWithFullContentOnListPage: [ "notes" ] # for which sections content should be displayed on list pages
   readMore: false # show read more button
   readNextPosts: 5  # show 5 related posts, 0 by default
   disableSummary: false

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,8 @@
 
     <div class="articles h-feed">
         <h1 class="post-title">{{ i18n .Title }}</h1>
-        {{ $pages := where (where .Pages "Type" "in" site.Params.mainSections) "Params.hidden" "!=" true}}
+        {{ $showFullContent := in .Site.Params.sectionsWithFullContentOnListPage .Section }}
+        {{ $pages := where .Pages "Params.hidden" "!=" true}}
         {{ range $pages }}
             <div class="post-short-list h-entry">
                 <div class="post-header">
@@ -14,6 +15,9 @@
                         {{ partial "post-language-switcher.html" . }}
                     </header>
                 </div>
+                {{ if $showFullContent }}
+                    {{ .Content }}
+                {{ end }}
                 {{ partial "post-info.html" . }}
             </div>
         {{ end }}


### PR DESCRIPTION
To show full content on list pages for some sections. 
I use it for Notes section (there is for future Mastodon integration, notes < 1000 symbols without titles)